### PR TITLE
Allow AWS Hosted DB Connection

### DIFF
--- a/db/connection.js
+++ b/db/connection.js
@@ -14,6 +14,10 @@ const config = {};
 if (ENV === "production") {
     config.connectionString = process.env.DATABASE_URL;
     config.max = 2;
+    // required as updated database host is in AWS cloud environment
+    config.ssl = {
+        rejectUnauthorized: false,
+    };
 }
 
 module.exports = new Pool(config);


### PR DESCRIPTION
Since ElephantSQL has been discontinued, the database used by the backend has been migrated to another provider.

This change updates the way connections are set up to allow the use of databases hosted in AWS.